### PR TITLE
Fixes multiscales to be a list

### DIFF
--- a/user_stories/image_registration_3d.zarr/FCWB/zarr.json
+++ b/user_stories/image_registration_3d.zarr/FCWB/zarr.json
@@ -4,79 +4,81 @@
   "attributes": {
     "ome": {
       "version": "0.6.dev1",
-      "multiscales": {
-        "name": "multiscales",
-        "coordinateSystems": [
-          {
-            "name": "FCWB",
-            "axes": [
-              {
-                "type": "space",
-                "name": "z",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "y",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "x",
-                "unit": "micrometer",
-                "discrete": false
-              }
-            ]
-          }
-        ],
-        "datasets": [
-          {
-            "path": "s0",
-            "coordinateTransformations": [
-              {
-                "type": "scale",
-                "output": "FCWB",
-                "input": "s0",
-                "scale": [
-                  1.2,
-                  1.2,
-                  1.2
-                ]
-              }
-            ]
-          },
-          {
-            "path": "s1",
-            "coordinateTransformations": [
-              {
-                "type": "sequence",
-                "output": "FCWB",
-                "input": "s1",
-                "transformations": [
-                  {
-                    "type": "scale",
-                    "scale": [
-                      2.4,
-                      2.4,
-                      2.4
-                    ]
-                  },
-                  {
-                    "type": "translation",
-                    "translation": [
-                      0.6,
-                      0.6,
-                      0.6
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "FCWB",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "z",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "s0",
+              "coordinateTransformations": [
+                {
+                  "type": "scale",
+                  "output": "FCWB",
+                  "input": "s0",
+                  "scale": [
+                    1.2,
+                    1.2,
+                    1.2
+                  ]
+                }
+              ]
+            },
+            {
+              "path": "s1",
+              "coordinateTransformations": [
+                {
+                  "type": "sequence",
+                  "output": "FCWB",
+                  "input": "s1",
+                  "transformations": [
+                    {
+                      "type": "scale",
+                      "scale": [
+                        2.4,
+                        2.4,
+                        2.4
+                      ]
+                    },
+                    {
+                      "type": "translation",
+                      "translation": [
+                        0.6,
+                        0.6,
+                        0.6
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/user_stories/image_registration_3d.zarr/JRC2018F/zarr.json
+++ b/user_stories/image_registration_3d.zarr/JRC2018F/zarr.json
@@ -4,79 +4,81 @@
   "attributes": {
     "ome": {
       "version": "0.6.dev1",
-      "multiscales": {
-        "name": "multiscales",
-        "coordinateSystems": [
-          {
-            "name": "JRC2018F",
-            "axes": [
-              {
-                "type": "space",
-                "name": "z",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "y",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "x",
-                "unit": "micrometer",
-                "discrete": false
-              }
-            ]
-          }
-        ],
-        "datasets": [
-          {
-            "path": "s0",
-            "coordinateTransformations": [
-              {
-                "type": "scale",
-                "output": "JRC2018F",
-                "input": "s0",
-                "scale": [
-                  1.24296,
-                  1.24296,
-                  1.24296
-                ]
-              }
-            ]
-          },
-          {
-            "path": "s1",
-            "coordinateTransformations": [
-              {
-                "type": "sequence",
-                "input": "s1",
-                "output": "JRC2018F",
-                "transformations": [
-                  {
-                    "type": "scale",
-                    "scale": [
-                      2.48592,
-                      2.48592,
-                      2.48592
-                    ]
-                  },
-                  {
-                    "type": "translation",
-                    "translation": [
-                      0.62148,
-                      0.62148,
-                      0.62148
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      }
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "JRC2018F",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "z",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "s0",
+              "coordinateTransformations": [
+                {
+                  "type": "scale",
+                  "output": "JRC2018F",
+                  "input": "s0",
+                  "scale": [
+                    1.24296,
+                    1.24296,
+                    1.24296
+                  ]
+                }
+              ]
+            },
+            {
+              "path": "s1",
+              "coordinateTransformations": [
+                {
+                  "type": "sequence",
+                  "input": "s1",
+                  "output": "JRC2018F",
+                  "transformations": [
+                    {
+                      "type": "scale",
+                      "scale": [
+                        2.48592,
+                        2.48592,
+                        2.48592
+                      ]
+                    },
+                    {
+                      "type": "translation",
+                      "translation": [
+                        0.62148,
+                        0.62148,
+                        0.62148
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/user_stories/lens_correction.zarr/image/zarr.json
+++ b/user_stories/lens_correction.zarr/image/zarr.json
@@ -4,51 +4,53 @@
   "attributes": {
     "ome": {
       "version": "0.6.dev1",
-      "multiscales": {
-        "name": "multiscales",
-        "coordinateSystems": [
-          {
-            "name": "raw",
-            "axes": [
-              {
-                "type": "space",
-                "name": "z",
-                "unit": "nanometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "y",
-                "unit": "nanometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "x",
-                "unit": "nanometer",
-                "discrete": false
-              }
-            ]
-          }
-        ],
-        "datasets": [
-          {
-            "path": "0",
-            "coordinateTransformations": [
-              {
-                "type": "scale",
-                "output": "raw",
-                "input": "0",
-                "scale": [
-                  1,
-                  1,
-                  1
-                ]
-              }
-            ]
-          }
-        ]
-      }
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "raw",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "z",
+                  "unit": "nanometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "nanometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "nanometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "0",
+              "coordinateTransformations": [
+                {
+                  "type": "scale",
+                  "output": "raw",
+                  "input": "0",
+                  "scale": [
+                    1,
+                    1,
+                    1
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/user_stories/stitched_tiles_2d.zarr/tile_0/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/tile_0/zarr.json
@@ -2,8 +2,8 @@
   "zarr_format": 3,
   "node_type": "group",
   "attributes": {
-    "version": "0.6.dev1",
     "ome": {
+      "version": "0.6.dev1",
       "multiscales": [
         {
           "name": "multiscales",

--- a/user_stories/stitched_tiles_2d.zarr/tile_0/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/tile_0/zarr.json
@@ -4,45 +4,47 @@
   "attributes": {
     "version": "0.6.dev1",
     "ome": {
-      "multiscales": {
-        "name": "multiscales",
-        "coordinateSystems": [
-          {
-            "name": "tile_0_mm",
-            "axes": [
-              {
-                "type": "space",
-                "name": "y",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "x",
-                "unit": "micrometer",
-                "discrete": false
-              }
-            ]
-          }
-        ],
-        "datasets": [
-          {
-            "path": "0",
-            "coordinateTransformations": [
-              {
-                "type": "scale",
-                "output": "tile_0_mm",
-                "input": "0",
-                "name": "tile_0 to physical",
-                "scale": [
-                  1,
-                  1
-                ]
-              }
-            ]
-          }
-        ]
-      }
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "tile_0_mm",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "0",
+              "coordinateTransformations": [
+                {
+                  "type": "scale",
+                  "output": "tile_0_mm",
+                  "input": "0",
+                  "name": "tile_0 to physical",
+                  "scale": [
+                    1,
+                    1
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/user_stories/stitched_tiles_2d.zarr/tile_1/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/tile_1/zarr.json
@@ -4,45 +4,47 @@
   "attributes": {
     "version": "0.6.dev1",
     "ome": {
-      "multiscales": {
-        "name": "multiscales",
-        "coordinateSystems": [
-          {
-            "name": "tile_1_mm",
-            "axes": [
-              {
-                "type": "space",
-                "name": "y",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "x",
-                "unit": "micrometer",
-                "discrete": false
-              }
-            ]
-          }
-        ],
-        "datasets": [
-          {
-            "path": "0",
-            "coordinateTransformations": [
-              {
-                "type": "scale",
-                "output": "tile_1_mm",
-                "input": "0",
-                "name": "tile_1 to physical",
-                "scale": [
-                  1,
-                  1
-                ]
-              }
-            ]
-          }
-        ]
-      }
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "tile_1_mm",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "0",
+              "coordinateTransformations": [
+                {
+                  "type": "scale",
+                  "output": "tile_1_mm",
+                  "input": "0",
+                  "name": "tile_1 to physical",
+                  "scale": [
+                    1,
+                    1
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/user_stories/stitched_tiles_2d.zarr/tile_1/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/tile_1/zarr.json
@@ -2,8 +2,8 @@
   "zarr_format": 3,
   "node_type": "group",
   "attributes": {
-    "version": "0.6.dev1",
     "ome": {
+      "version": "0.6.dev1",
       "multiscales": [
         {
           "name": "multiscales",

--- a/user_stories/stitched_tiles_2d.zarr/tile_2/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/tile_2/zarr.json
@@ -4,45 +4,47 @@
   "attributes": {
     "version": "0.6.dev1",
     "ome": {
-      "multiscales": {
-        "name": "multiscales",
-        "coordinateSystems": [
-          {
-            "name": "tile_2_mm",
-            "axes": [
-              {
-                "type": "space",
-                "name": "y",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "x",
-                "unit": "micrometer",
-                "discrete": false
-              }
-            ]
-          }
-        ],
-        "datasets": [
-          {
-            "path": "0",
-            "coordinateTransformations": [
-              {
-                "type": "scale",
-                "output": "tile_2_mm",
-                "input": "0",
-                "name": "tile_2 to physical",
-                "scale": [
-                  1,
-                  1
-                ]
-              }
-            ]
-          }
-        ]
-      }
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "tile_2_mm",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "0",
+              "coordinateTransformations": [
+                {
+                  "type": "scale",
+                  "output": "tile_2_mm",
+                  "input": "0",
+                  "name": "tile_2 to physical",
+                  "scale": [
+                    1,
+                    1
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/user_stories/stitched_tiles_2d.zarr/tile_2/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/tile_2/zarr.json
@@ -2,8 +2,8 @@
   "zarr_format": 3,
   "node_type": "group",
   "attributes": {
-    "version": "0.6.dev1",
     "ome": {
+      "version": "0.6.dev1",
       "multiscales": [
         {
           "name": "multiscales",

--- a/user_stories/stitched_tiles_2d.zarr/tile_3/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/tile_3/zarr.json
@@ -2,8 +2,8 @@
   "zarr_format": 3,
   "node_type": "group",
   "attributes": {
-    "version": "0.6.dev1",
     "ome": {
+      "version": "0.6.dev1",
       "multiscales": [
         {
           "name": "multiscales",

--- a/user_stories/stitched_tiles_2d.zarr/tile_3/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/tile_3/zarr.json
@@ -4,45 +4,47 @@
   "attributes": {
     "version": "0.6.dev1",
     "ome": {
-      "multiscales": {
-        "name": "multiscales",
-        "coordinateSystems": [
-          {
-            "name": "tile_3_mm",
-            "axes": [
-              {
-                "type": "space",
-                "name": "y",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "x",
-                "unit": "micrometer",
-                "discrete": false
-              }
-            ]
-          }
-        ],
-        "datasets": [
-          {
-            "path": "0",
-            "coordinateTransformations": [
-              {
-                "type": "scale",
-                "output": "tile_3_mm",
-                "input": "0",
-                "name": "tile_3 to physical",
-                "scale": [
-                  1,
-                  1
-                ]
-              }
-            ]
-          }
-        ]
-      }
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "tile_3_mm",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "0",
+              "coordinateTransformations": [
+                {
+                  "type": "scale",
+                  "output": "tile_3_mm",
+                  "input": "0",
+                  "name": "tile_3 to physical",
+                  "scale": [
+                    1,
+                    1
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/user_stories/stitched_tiles_3d.zarr/tile_0/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_0/zarr.json
@@ -2,8 +2,8 @@
   "zarr_format": 3,
   "node_type": "group",
   "attributes": {
-    "version": "0.6.dev1",
     "ome": {
+      "version": "0.6.dev1",
       "multiscales": [
         {
           "name": "multiscales",

--- a/user_stories/stitched_tiles_3d.zarr/tile_0/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_0/zarr.json
@@ -4,51 +4,53 @@
   "attributes": {
     "version": "0.6.dev1",
     "ome": {
-      "multiscales": {
-        "name": "multiscales",
-        "coordinateSystems": [
-          {
-            "name": "tile_0_mm",
-            "axes": [
-              {
-                "type": "space",
-                "name": "z",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "y",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "x",
-                "unit": "micrometer",
-                "discrete": false
-              }
-            ]
-          }
-        ],
-        "datasets": [
-          {
-            "path": "0",
-            "coordinateTransformations": [
-              {
-                "type": "scale",
-                "output": "tile_0_mm",
-                "input": "0",
-                "name": "tile_0 to physical",
-                "scale": [
-                  1,
-                  1
-                ]
-              }
-            ]
-          }
-        ]
-      }
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "tile_0_mm",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "z",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "0",
+              "coordinateTransformations": [
+                {
+                  "type": "scale",
+                  "output": "tile_0_mm",
+                  "input": "0",
+                  "name": "tile_0 to physical",
+                  "scale": [
+                    1,
+                    1
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/user_stories/stitched_tiles_3d.zarr/tile_1/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_1/zarr.json
@@ -2,8 +2,8 @@
   "zarr_format": 3,
   "node_type": "group",
   "attributes": {
-    "version": "0.6.dev1",
     "ome": {
+      "version": "0.6.dev1",
       "multiscales": [
         {
           "name": "multiscales",

--- a/user_stories/stitched_tiles_3d.zarr/tile_1/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_1/zarr.json
@@ -4,51 +4,53 @@
   "attributes": {
     "version": "0.6.dev1",
     "ome": {
-      "multiscales": {
-        "name": "multiscales",
-        "coordinateSystems": [
-          {
-            "name": "tile_1_mm",
-            "axes": [
-              {
-                "type": "space",
-                "name": "z",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "y",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "x",
-                "unit": "micrometer",
-                "discrete": false
-              }
-            ]
-          }
-        ],
-        "datasets": [
-          {
-            "path": "0",
-            "coordinateTransformations": [
-              {
-                "type": "scale",
-                "output": "tile_1_mm",
-                "input": "0",
-                "name": "tile_1 to physical",
-                "scale": [
-                  1,
-                  1
-                ]
-              }
-            ]
-          }
-        ]
-      }
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "tile_1_mm",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "z",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "0",
+              "coordinateTransformations": [
+                {
+                  "type": "scale",
+                  "output": "tile_1_mm",
+                  "input": "0",
+                  "name": "tile_1 to physical",
+                  "scale": [
+                    1,
+                    1
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/user_stories/stitched_tiles_3d.zarr/tile_2/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_2/zarr.json
@@ -2,8 +2,8 @@
   "zarr_format": 3,
   "node_type": "group",
   "attributes": {
-    "version": "0.6.dev1",
     "ome": {
+      "version": "0.6.dev1",
       "multiscales": [
         {
           "name": "multiscales",

--- a/user_stories/stitched_tiles_3d.zarr/tile_2/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_2/zarr.json
@@ -4,51 +4,53 @@
   "attributes": {
     "version": "0.6.dev1",
     "ome": {
-      "multiscales": {
-        "name": "multiscales",
-        "coordinateSystems": [
-          {
-            "name": "tile_2_mm",
-            "axes": [
-              {
-                "type": "space",
-                "name": "z",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "y",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "x",
-                "unit": "micrometer",
-                "discrete": false
-              }
-            ]
-          }
-        ],
-        "datasets": [
-          {
-            "path": "0",
-            "coordinateTransformations": [
-              {
-                "type": "scale",
-                "output": "tile_2_mm",
-                "input": "0",
-                "name": "tile_2 to physical",
-                "scale": [
-                  1,
-                  1
-                ]
-              }
-            ]
-          }
-        ]
-      }
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "tile_2_mm",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "z",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "0",
+              "coordinateTransformations": [
+                {
+                  "type": "scale",
+                  "output": "tile_2_mm",
+                  "input": "0",
+                  "name": "tile_2 to physical",
+                  "scale": [
+                    1,
+                    1
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/user_stories/stitched_tiles_3d.zarr/tile_3/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_3/zarr.json
@@ -2,8 +2,8 @@
   "zarr_format": 3,
   "node_type": "group",
   "attributes": {
-    "version": "0.6.dev1",
     "ome": {
+      "version": "0.6.dev1",
       "multiscales": [
         {
           "name": "multiscales",

--- a/user_stories/stitched_tiles_3d.zarr/tile_3/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_3/zarr.json
@@ -4,51 +4,53 @@
   "attributes": {
     "version": "0.6.dev1",
     "ome": {
-      "multiscales": {
-        "name": "multiscales",
-        "coordinateSystems": [
-          {
-            "name": "tile_3_mm",
-            "axes": [
-              {
-                "type": "space",
-                "name": "z",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "y",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "x",
-                "unit": "micrometer",
-                "discrete": false
-              }
-            ]
-          }
-        ],
-        "datasets": [
-          {
-            "path": "0",
-            "coordinateTransformations": [
-              {
-                "type": "scale",
-                "output": "tile_3_mm",
-                "input": "0",
-                "name": "tile_3 to physical",
-                "scale": [
-                  1,
-                  1
-                ]
-              }
-            ]
-          }
-        ]
-      }
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "tile_3_mm",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "z",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "0",
+              "coordinateTransformations": [
+                {
+                  "type": "scale",
+                  "output": "tile_3_mm",
+                  "input": "0",
+                  "name": "tile_3 to physical",
+                  "scale": [
+                    1,
+                    1
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/user_stories/stitched_tiles_3d.zarr/tile_4/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_4/zarr.json
@@ -2,8 +2,8 @@
   "zarr_format": 3,
   "node_type": "group",
   "attributes": {
-    "version": "0.6.dev1",
     "ome": {
+      "version": "0.6.dev1",
       "multiscales": [
         {
           "name": "multiscales",

--- a/user_stories/stitched_tiles_3d.zarr/tile_4/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_4/zarr.json
@@ -4,51 +4,53 @@
   "attributes": {
     "version": "0.6.dev1",
     "ome": {
-      "multiscales": {
-        "name": "multiscales",
-        "coordinateSystems": [
-          {
-            "name": "tile_4_mm",
-            "axes": [
-              {
-                "type": "space",
-                "name": "z",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "y",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "x",
-                "unit": "micrometer",
-                "discrete": false
-              }
-            ]
-          }
-        ],
-        "datasets": [
-          {
-            "path": "0",
-            "coordinateTransformations": [
-              {
-                "type": "scale",
-                "output": "tile_4_mm",
-                "input": "0",
-                "name": "tile_4 to physical",
-                "scale": [
-                  1,
-                  1
-                ]
-              }
-            ]
-          }
-        ]
-      }
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "tile_4_mm",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "z",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "0",
+              "coordinateTransformations": [
+                {
+                  "type": "scale",
+                  "output": "tile_4_mm",
+                  "input": "0",
+                  "name": "tile_4 to physical",
+                  "scale": [
+                    1,
+                    1
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/user_stories/stitched_tiles_3d.zarr/tile_5/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_5/zarr.json
@@ -4,51 +4,53 @@
   "attributes": {
     "version": "0.6.dev1",
     "ome": {
-      "multiscales": {
-        "name": "multiscales",
-        "coordinateSystems": [
-          {
-            "name": "tile_5_mm",
-            "axes": [
-              {
-                "type": "space",
-                "name": "z",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "y",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "x",
-                "unit": "micrometer",
-                "discrete": false
-              }
-            ]
-          }
-        ],
-        "datasets": [
-          {
-            "path": "0",
-            "coordinateTransformations": [
-              {
-                "type": "scale",
-                "output": "tile_5_mm",
-                "input": "0",
-                "name": "tile_5 to physical",
-                "scale": [
-                  1,
-                  1
-                ]
-              }
-            ]
-          }
-        ]
-      }
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "tile_5_mm",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "z",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "0",
+              "coordinateTransformations": [
+                {
+                  "type": "scale",
+                  "output": "tile_5_mm",
+                  "input": "0",
+                  "name": "tile_5 to physical",
+                  "scale": [
+                    1,
+                    1
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/user_stories/stitched_tiles_3d.zarr/tile_5/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_5/zarr.json
@@ -2,8 +2,8 @@
   "zarr_format": 3,
   "node_type": "group",
   "attributes": {
-    "version": "0.6.dev1",
     "ome": {
+      "version": "0.6.dev1",
       "multiscales": [
         {
           "name": "multiscales",

--- a/user_stories/stitched_tiles_3d.zarr/tile_6/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_6/zarr.json
@@ -4,51 +4,53 @@
   "attributes": {
     "version": "0.6.dev1",
     "ome": {
-      "multiscales": {
-        "name": "multiscales",
-        "coordinateSystems": [
-          {
-            "name": "tile_6_mm",
-            "axes": [
-              {
-                "type": "space",
-                "name": "z",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "y",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "x",
-                "unit": "micrometer",
-                "discrete": false
-              }
-            ]
-          }
-        ],
-        "datasets": [
-          {
-            "path": "0",
-            "coordinateTransformations": [
-              {
-                "type": "scale",
-                "output": "tile_6_mm",
-                "input": "0",
-                "name": "tile_6 to physical",
-                "scale": [
-                  1,
-                  1
-                ]
-              }
-            ]
-          }
-        ]
-      }
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "tile_6_mm",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "z",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "0",
+              "coordinateTransformations": [
+                {
+                  "type": "scale",
+                  "output": "tile_6_mm",
+                  "input": "0",
+                  "name": "tile_6 to physical",
+                  "scale": [
+                    1,
+                    1
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/user_stories/stitched_tiles_3d.zarr/tile_6/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_6/zarr.json
@@ -2,8 +2,8 @@
   "zarr_format": 3,
   "node_type": "group",
   "attributes": {
-    "version": "0.6.dev1",
     "ome": {
+      "version": "0.6.dev1",
       "multiscales": [
         {
           "name": "multiscales",

--- a/user_stories/stitched_tiles_3d.zarr/tile_7/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_7/zarr.json
@@ -4,51 +4,53 @@
   "attributes": {
     "version": "0.6.dev1",
     "ome": {
-      "multiscales": {
-        "name": "multiscales",
-        "coordinateSystems": [
-          {
-            "name": "tile_7_mm",
-            "axes": [
-              {
-                "type": "space",
-                "name": "z",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "y",
-                "unit": "micrometer",
-                "discrete": false
-              },
-              {
-                "type": "space",
-                "name": "x",
-                "unit": "micrometer",
-                "discrete": false
-              }
-            ]
-          }
-        ],
-        "datasets": [
-          {
-            "path": "0",
-            "coordinateTransformations": [
-              {
-                "type": "scale",
-                "output": "tile_7_mm",
-                "input": "0",
-                "name": "tile_7 to physical",
-                "scale": [
-                  1,
-                  1
-                ]
-              }
-            ]
-          }
-        ]
-      }
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "tile_7_mm",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "z",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "0",
+              "coordinateTransformations": [
+                {
+                  "type": "scale",
+                  "output": "tile_7_mm",
+                  "input": "0",
+                  "name": "tile_7 to physical",
+                  "scale": [
+                    1,
+                    1
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/user_stories/stitched_tiles_3d.zarr/tile_7/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_7/zarr.json
@@ -2,8 +2,8 @@
   "zarr_format": 3,
   "node_type": "group",
   "attributes": {
-    "version": "0.6.dev1",
     "ome": {
+      "version": "0.6.dev1",
       "multiscales": [
         {
           "name": "multiscales",


### PR DESCRIPTION
Simply edit `"multiscales": { }` to `"multiscales": [{ }]` for a bunch of samples.

Diffs look a lot bigger because of indentation.