### PR TITLE
Fix zstd codec name

### DIFF
--- a/2d/axis_dependent/byDimension.zarr/array/zarr.json
+++ b/2d/axis_dependent/byDimension.zarr/array/zarr.json
@@ -6,17 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    576,
-    720
-  ],
+  "shape": [576, 720],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        576,
-        720
-      ]
+      "chunk_shape": [576, 720]
     }
   },
   "codecs": [
@@ -27,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/2d/axis_dependent/mapAxis.zarr/array/zarr.json
+++ b/2d/axis_dependent/mapAxis.zarr/array/zarr.json
@@ -6,17 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    576,
-    720
-  ],
+  "shape": [576, 720],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        576,
-        720
-      ]
+      "chunk_shape": [576, 720]
     }
   },
   "codecs": [
@@ -27,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/2d/basic/identity.zarr/array/zarr.json
+++ b/2d/basic/identity.zarr/array/zarr.json
@@ -6,17 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    576,
-    720
-  ],
+  "shape": [576, 720],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        576,
-        720
-      ]
+      "chunk_shape": [576, 720]
     }
   },
   "codecs": [
@@ -27,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/2d/basic/scale.zarr/array/zarr.json
+++ b/2d/basic/scale.zarr/array/zarr.json
@@ -6,17 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    576,
-    720
-  ],
+  "shape": [576, 720],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        576,
-        720
-      ]
+      "chunk_shape": [576, 720]
     }
   },
   "codecs": [
@@ -27,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/2d/basic/sequenceScaleTranslation.zarr/array/zarr.json
+++ b/2d/basic/sequenceScaleTranslation.zarr/array/zarr.json
@@ -6,17 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    576,
-    720
-  ],
+  "shape": [576, 720],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        576,
-        720
-      ]
+      "chunk_shape": [576, 720]
     }
   },
   "codecs": [
@@ -27,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/2d/basic/translation.zarr/array/zarr.json
+++ b/2d/basic/translation.zarr/array/zarr.json
@@ -6,17 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    576,
-    720
-  ],
+  "shape": [576, 720],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        576,
-        720
-      ]
+      "chunk_shape": [576, 720]
     }
   },
   "codecs": [
@@ -27,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/2d/basic_binary/scaleParams.zarr/array/zarr.json
+++ b/2d/basic_binary/scaleParams.zarr/array/zarr.json
@@ -6,17 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    576,
-    720
-  ],
+  "shape": [576, 720],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        576,
-        720
-      ]
+      "chunk_shape": [576, 720]
     }
   },
   "codecs": [
@@ -27,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/2d/basic_binary/translationParams.zarr/array/zarr.json
+++ b/2d/basic_binary/translationParams.zarr/array/zarr.json
@@ -6,17 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    576,
-    720
-  ],
+  "shape": [576, 720],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        576,
-        720
-      ]
+      "chunk_shape": [576, 720]
     }
   },
   "codecs": [
@@ -27,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/2d/nonlinear/invCoordinates.zarr/coordinatesField/zarr.json
+++ b/2d/nonlinear/invCoordinates.zarr/coordinatesField/zarr.json
@@ -1,19 +1,11 @@
 {
   "node_type": "array",
   "zarr_format": 3,
-  "shape": [
-    576,
-    720,
-    2
-  ],
+  "shape": [576, 720, 2],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        576,
-        720,
-        2
-      ]
+      "chunk_shape": [576, 720, 2]
     }
   },
   "chunk_key_encoding": {
@@ -24,11 +16,7 @@
   },
   "data_type": "float64",
   "fill_value": 0,
-  "dimension_names": [
-    "y",
-    "x",
-    "c"
-  ],
+  "dimension_names": ["y", "x", "c"],
   "codecs": [
     {
       "name": "bytes",
@@ -37,7 +25,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }
@@ -72,11 +60,7 @@
           "type": "scale",
           "output": "0",
           "input": "0",
-          "scale": [
-            1,
-            1,
-            1
-          ]
+          "scale": [1, 1, 1]
         }
       ]
     }

--- a/2d/nonlinear/invDisplacements.zarr/displacementField/zarr.json
+++ b/2d/nonlinear/invDisplacements.zarr/displacementField/zarr.json
@@ -1,19 +1,11 @@
 {
   "node_type": "array",
   "zarr_format": 3,
-  "shape": [
-    576,
-    720,
-    2
-  ],
+  "shape": [576, 720, 2],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        576,
-        720,
-        2
-      ]
+      "chunk_shape": [576, 720, 2]
     }
   },
   "chunk_key_encoding": {
@@ -24,11 +16,7 @@
   },
   "data_type": "float64",
   "fill_value": 0,
-  "dimension_names": [
-    "y",
-    "x",
-    "d"
-  ],
+  "dimension_names": ["y", "x", "d"],
   "codecs": [
     {
       "name": "bytes",
@@ -37,7 +25,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }
@@ -72,11 +60,7 @@
           "type": "scale",
           "output": "0",
           "input": "0",
-          "scale": [
-            1,
-            1,
-            1
-          ]
+          "scale": [1, 1, 1]
         }
       ]
     }

--- a/2d/simple/affine.zarr/array/zarr.json
+++ b/2d/simple/affine.zarr/array/zarr.json
@@ -6,17 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    576,
-    720
-  ],
+  "shape": [576, 720],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        576,
-        720
-      ]
+      "chunk_shape": [576, 720]
     }
   },
   "codecs": [
@@ -27,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/2d/simple/affineParams.zarr/array/zarr.json
+++ b/2d/simple/affineParams.zarr/array/zarr.json
@@ -6,17 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    576,
-    720
-  ],
+  "shape": [576, 720],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        576,
-        720
-      ]
+      "chunk_shape": [576, 720]
     }
   },
   "codecs": [
@@ -27,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/2d/simple/rotation.zarr/array/zarr.json
+++ b/2d/simple/rotation.zarr/array/zarr.json
@@ -6,17 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    576,
-    720
-  ],
+  "shape": [576, 720],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        576,
-        720
-      ]
+      "chunk_shape": [576, 720]
     }
   },
   "codecs": [
@@ -27,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/2d/simple/rotationParams.zarr/array/zarr.json
+++ b/2d/simple/rotationParams.zarr/array/zarr.json
@@ -6,17 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    576,
-    720
-  ],
+  "shape": [576, 720],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        576,
-        720
-      ]
+      "chunk_shape": [576, 720]
     }
   },
   "codecs": [
@@ -27,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/3d/axis_dependent/byDimension.zarr/array/zarr.json
+++ b/3d/axis_dependent/byDimension.zarr/array/zarr.json
@@ -6,19 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    27,
-    226,
-    186
-  ],
+  "shape": [27, 226, 186],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        27,
-        226,
-        186
-      ]
+      "chunk_shape": [27, 226, 186]
     }
   },
   "codecs": [
@@ -29,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/3d/axis_dependent/mapAxis.zarr/array/zarr.json
+++ b/3d/axis_dependent/mapAxis.zarr/array/zarr.json
@@ -6,19 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    27,
-    226,
-    186
-  ],
+  "shape": [27, 226, 186],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        27,
-        226,
-        186
-      ]
+      "chunk_shape": [27, 226, 186]
     }
   },
   "codecs": [
@@ -29,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/3d/basic/identity.zarr/array/zarr.json
+++ b/3d/basic/identity.zarr/array/zarr.json
@@ -6,19 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    27,
-    226,
-    186
-  ],
+  "shape": [27, 226, 186],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        27,
-        226,
-        186
-      ]
+      "chunk_shape": [27, 226, 186]
     }
   },
   "codecs": [
@@ -29,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/3d/basic/scale.zarr/array/zarr.json
+++ b/3d/basic/scale.zarr/array/zarr.json
@@ -6,19 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    27,
-    226,
-    186
-  ],
+  "shape": [27, 226, 186],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        27,
-        226,
-        186
-      ]
+      "chunk_shape": [27, 226, 186]
     }
   },
   "codecs": [
@@ -29,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/3d/basic/sequenceScaleTranslation.zarr/array/zarr.json
+++ b/3d/basic/sequenceScaleTranslation.zarr/array/zarr.json
@@ -6,19 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    27,
-    226,
-    186
-  ],
+  "shape": [27, 226, 186],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        27,
-        226,
-        186
-      ]
+      "chunk_shape": [27, 226, 186]
     }
   },
   "codecs": [
@@ -29,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/3d/basic/translation.zarr/array/zarr.json
+++ b/3d/basic/translation.zarr/array/zarr.json
@@ -6,19 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    27,
-    226,
-    186
-  ],
+  "shape": [27, 226, 186],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        27,
-        226,
-        186
-      ]
+      "chunk_shape": [27, 226, 186]
     }
   },
   "codecs": [
@@ -29,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/3d/basic_binary/scaleParams.zarr/array/zarr.json
+++ b/3d/basic_binary/scaleParams.zarr/array/zarr.json
@@ -6,19 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    27,
-    226,
-    186
-  ],
+  "shape": [27, 226, 186],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        27,
-        226,
-        186
-      ]
+      "chunk_shape": [27, 226, 186]
     }
   },
   "codecs": [
@@ -29,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/3d/basic_binary/translationParams.zarr/array/zarr.json
+++ b/3d/basic_binary/translationParams.zarr/array/zarr.json
@@ -6,19 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    27,
-    226,
-    186
-  ],
+  "shape": [27, 226, 186],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        27,
-        226,
-        186
-      ]
+      "chunk_shape": [27, 226, 186]
     }
   },
   "codecs": [
@@ -29,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/3d/nonlinear/invCoordinates.zarr/coordinatesField/zarr.json
+++ b/3d/nonlinear/invCoordinates.zarr/coordinatesField/zarr.json
@@ -1,21 +1,11 @@
 {
   "node_type": "array",
   "zarr_format": 3,
-  "shape": [
-    27,
-    226,
-    186,
-    3
-  ],
+  "shape": [27, 226, 186, 3],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        27,
-        226,
-        186,
-        3
-      ]
+      "chunk_shape": [27, 226, 186, 3]
     }
   },
   "chunk_key_encoding": {
@@ -34,7 +24,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }
@@ -74,12 +64,7 @@
           "type": "scale",
           "output": "0",
           "input": "0",
-          "scale": [
-            1,
-            1,
-            1,
-            1
-          ]
+          "scale": [1, 1, 1, 1]
         }
       ]
     }

--- a/3d/nonlinear/invDisplacements.zarr/displacementField/zarr.json
+++ b/3d/nonlinear/invDisplacements.zarr/displacementField/zarr.json
@@ -1,21 +1,11 @@
 {
   "node_type": "array",
   "zarr_format": 3,
-  "shape": [
-    27,
-    226,
-    186,
-    3
-  ],
+  "shape": [27, 226, 186, 3],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        27,
-        226,
-        186,
-        3
-      ]
+      "chunk_shape": [27, 226, 186, 3]
     }
   },
   "chunk_key_encoding": {
@@ -34,18 +24,13 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }
     }
   ],
-  "dimension_names": [
-    "z",
-    "y",
-    "x",
-    "d"
-  ],
+  "dimension_names": ["z", "y", "x", "d"],
   "attributes": {
     "ome": {
       "coordinateSystems": [
@@ -80,12 +65,7 @@
           "type": "scale",
           "output": "0",
           "input": "0",
-          "scale": [
-            1,
-            1,
-            1,
-            1
-          ]
+          "scale": [1, 1, 1, 1]
         }
       ]
     }

--- a/3d/simple/affine.zarr/array/zarr.json
+++ b/3d/simple/affine.zarr/array/zarr.json
@@ -6,19 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    27,
-    226,
-    186
-  ],
+  "shape": [27, 226, 186],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        27,
-        226,
-        186
-      ]
+      "chunk_shape": [27, 226, 186]
     }
   },
   "codecs": [
@@ -29,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/3d/simple/affineParams.zarr/array/zarr.json
+++ b/3d/simple/affineParams.zarr/array/zarr.json
@@ -6,19 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    27,
-    226,
-    186
-  ],
+  "shape": [27, 226, 186],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        27,
-        226,
-        186
-      ]
+      "chunk_shape": [27, 226, 186]
     }
   },
   "codecs": [
@@ -29,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/3d/simple/rotation.zarr/array/zarr.json
+++ b/3d/simple/rotation.zarr/array/zarr.json
@@ -6,19 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    27,
-    226,
-    186
-  ],
+  "shape": [27, 226, 186],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        27,
-        226,
-        186
-      ]
+      "chunk_shape": [27, 226, 186]
     }
   },
   "codecs": [
@@ -29,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/3d/simple/rotationParams.zarr/array/zarr.json
+++ b/3d/simple/rotationParams.zarr/array/zarr.json
@@ -6,19 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    27,
-    226,
-    186
-  ],
+  "shape": [27, 226, 186],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        27,
-        226,
-        186
-      ]
+      "chunk_shape": [27, 226, 186]
     }
   },
   "codecs": [
@@ -29,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }

--- a/bigwarp/installToFiji
+++ b/bigwarp/installToFiji
@@ -16,7 +16,7 @@ rm $fijiPath/jars/n5-ij*jar
 rm $fijiPath/jars/n5-imglib2*jar
 rm $fijiPath/jars/n5-universe*jar
 rm $fijiPath/jars/n5-zarr*jar
-rm $fijiPath/jars/n5-zstandard*jar
+rm $fijiPath/jars/n5-zstd*jar
 
 rm $fijiPath/plugins/n5-viewer*jar
 rm $fijiPath/plugins/bigwarp*jar

--- a/user_stories/image_registration_3d.zarr/coordinateTransformations/dfield/zarr.json
+++ b/user_stories/image_registration_3d.zarr/coordinateTransformations/dfield/zarr.json
@@ -6,27 +6,12 @@
       "separator": "/"
     }
   },
-  "shape": [
-    104,
-    166,
-    357,
-    3
-  ],
-  "dimension_names": [
-    "z",
-    "y",
-    "x",
-    "d"
-  ],
+  "shape": [104, 166, 357, 3],
+  "dimension_names": ["z", "y", "x", "d"],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        64,
-        64,
-        64,
-        3
-      ]
+      "chunk_shape": [64, 64, 64, 3]
     }
   },
   "codecs": [
@@ -37,7 +22,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }
@@ -84,12 +69,7 @@
           "output": "JRC2018F",
           "input": "dfield",
           "name": "",
-          "scale": [
-            1.76,
-            1.76,
-            1.76,
-            1
-          ]
+          "scale": [1.76, 1.76, 1.76, 1]
         }
       ]
     }

--- a/user_stories/image_registration_3d.zarr/coordinateTransformations/invdfield/zarr.json
+++ b/user_stories/image_registration_3d.zarr/coordinateTransformations/invdfield/zarr.json
@@ -6,21 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    104,
-    166,
-    357,
-    3
-  ],
+  "shape": [104, 166, 357, 3],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        64,
-        64,
-        64,
-        3
-      ]
+      "chunk_shape": [64, 64, 64, 3]
     }
   },
   "codecs": [
@@ -31,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }
@@ -78,12 +68,7 @@
           "output": "FCWB",
           "input": "invdfield",
           "name": "",
-          "scale": [
-            1.76,
-            1.76,
-            1.76,
-            1
-          ]
+          "scale": [1.76, 1.76, 1.76, 1]
         }
       ]
     }

--- a/user_stories/lens_correction.zarr/coordinateTransformations/lensCorrection/zarr.json
+++ b/user_stories/lens_correction.zarr/coordinateTransformations/lensCorrection/zarr.json
@@ -6,19 +6,11 @@
       "separator": "/"
     }
   },
-  "shape": [
-    26,
-    26,
-    2
-  ],
+  "shape": [26, 26, 2],
   "chunk_grid": {
     "name": "regular",
     "configuration": {
-      "chunk_shape": [
-        26,
-        2,
-        2
-      ]
+      "chunk_shape": [26, 2, 2]
     }
   },
   "codecs": [
@@ -29,7 +21,7 @@
       }
     },
     {
-      "name": "zstandard",
+      "name": "zstd",
       "configuration": {
         "level": 3
       }
@@ -70,11 +62,7 @@
           "output": "raw2d",
           "input": ".",
           "name": "displacement field sample spacing",
-          "scale": [
-            5,
-            5,
-            1
-          ]
+          "scale": [5, 5, 1]
         }
       ]
     }


### PR DESCRIPTION
In Python at least, these zarr groups fail to load because the codec ID for Zstandard is expected to be `zstd`, not `zstandard`. The other way to fix this is just to remove the compression codecs completely from the metadata, since they are not needed for these arrays.