### PR TITLE
Fix inputs in displacements

### DIFF
--- a/2d/axis_dependent/byDimension.zarr/zarr.json
+++ b/2d/axis_dependent/byDimension.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -47,8 +47,8 @@
               "coordinateTransformations": [
                 {
                   "type": "identity",
-                  "output": "array_coordinates",
-                  "input": "s0",
+                  "output": {"name": "array_coordinates"},
+                  "input": {"path": "s0"},
                   "name": "transform-name"
                 }
               ]
@@ -57,8 +57,8 @@
           "coordinateTransformations": [
             {
               "type": "byDimension",
-              "output": "physical",
-              "input": "array_coordinates",
+              "output": {"name": "physical"},
+              "input": {"name": "array_coordinates"},
               "transformations": [
                 {
                   "transformation": {

--- a/2d/axis_dependent/mapAxis.zarr/zarr.json
+++ b/2d/axis_dependent/mapAxis.zarr/zarr.json
@@ -29,12 +29,12 @@
               "name": "array_coordinates",
               "axes": [
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "dim_0",
                   "discrete": true
                 },
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "dim_1",
                   "discrete": true
                 }

--- a/2d/axis_dependent/mapAxis.zarr/zarr.json
+++ b/2d/axis_dependent/mapAxis.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -47,8 +47,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "array_coordinates",
-                  "input": "array",
+                  "output": {"name": "array_coordinates"},
+                  "input": {"path": "array"},
                   "name": "default-scale",
                   "scale": [1, 1]
                 }
@@ -58,8 +58,8 @@
           "coordinateTransformations": [
             {
               "type": "mapAxis",
-              "output": "physical",
-              "input": "array_coordinates",
+              "output": {"name": "physical"},
+              "input": {"name": "array_coordinates"},
               "name": "transform-name",
               "mapAxis": [1, 0]
             }

--- a/2d/basic/identity.zarr/zarr.json
+++ b/2d/basic/identity.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "identity",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "transform-name"
                 }
               ]

--- a/2d/basic/scale.zarr/zarr.json
+++ b/2d/basic/scale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "transform-name",
                   "scale": [
                     3.0,

--- a/2d/basic/scale_multiscale.zarr/zarr.json
+++ b/2d/basic/scale_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "s0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s0"},
                   "name": "transform-name",
                   "scale": [
                     6.0,
@@ -47,8 +47,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "s1",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s1"},
                   "name": "transform-name",
                   "scale": [
                     12.0,
@@ -62,8 +62,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "s2",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s2"},
                   "name": "transform-name",
                   "scale": [
                     24.0,

--- a/2d/basic/sequenceScaleTranslation.zarr/zarr.json
+++ b/2d/basic/sequenceScaleTranslation.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/2d/basic/sequenceScaleTranslation_multiscale.zarr/zarr.json
+++ b/2d/basic/sequenceScaleTranslation_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s0"},
                   "transformations": [
                     {
                       "type": "scale",
@@ -60,8 +60,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s1",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s1"},
                   "transformations": [
                     {
                       "type": "scale",
@@ -88,8 +88,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s2",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s2"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/2d/nonlinear/coordinates.zarr/coordinatesField/zarr.json
+++ b/2d/nonlinear/coordinates.zarr/coordinatesField/zarr.json
@@ -70,8 +70,8 @@
       "coordinateTransformations": [
         {
           "type": "scale",
-          "output": "0",
-          "input": "0",
+          "output": {"name": "0"},
+          "input": {"path": "0"},
           "scale": [
             1,
             1,

--- a/2d/nonlinear/coordinates.zarr/coordinatesField/zarr.json
+++ b/2d/nonlinear/coordinates.zarr/coordinatesField/zarr.json
@@ -71,7 +71,6 @@
         {
           "type": "scale",
           "output": {"name": "0"},
-          "input": {"path": "0"},
           "scale": [
             1,
             1,

--- a/2d/nonlinear/coordinates.zarr/zarr.json
+++ b/2d/nonlinear/coordinates.zarr/zarr.json
@@ -29,12 +29,12 @@
               "name": "scaled",
               "axes": [
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "y",
                   "discrete": false
                 },
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "x",
                   "discrete": false
                 }

--- a/2d/nonlinear/coordinates.zarr/zarr.json
+++ b/2d/nonlinear/coordinates.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -47,8 +47,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "scaled",
-                  "input": "0",
+                  "output": {"name": "scaled"},
+                  "input": {"path": "0"},
                   "scale": [1, 1],
                   "name": "tform-name"
                 }
@@ -58,8 +58,8 @@
           "coordinateTransformations": [
             {
               "type": "coordinates",
-              "output": "scaled",
-              "input": "physical",
+              "output": {"name": "scaled"},
+              "input": {"name": "physical"},
               "path": "coordinatesField",
               "interpolation": "linear",
               "name": "inverse-cfield"

--- a/2d/nonlinear/displacements.zarr/displacementField/zarr.json
+++ b/2d/nonlinear/displacements.zarr/displacementField/zarr.json
@@ -70,8 +70,8 @@
       "coordinateTransformations": [
         {
           "type": "scale",
-          "output": "0",
-          "input": "0",
+          "output": {"name": "0"},
+          "input": {"path": "0"},
           "scale": [
             1,
             1,

--- a/2d/nonlinear/displacements.zarr/displacementField/zarr.json
+++ b/2d/nonlinear/displacements.zarr/displacementField/zarr.json
@@ -71,7 +71,6 @@
         {
           "type": "scale",
           "output": {"name": "0"},
-          "input": {"path": "0"},
           "scale": [
             1,
             1,

--- a/2d/nonlinear/displacements.zarr/zarr.json
+++ b/2d/nonlinear/displacements.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -47,8 +47,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "scale": [1, 1],
                   "name": "scale-transform"
                 }
@@ -58,8 +58,8 @@
           "coordinateTransformations": [
             {
               "type": "displacements",
-              "output": "displaced",
-              "input": "physical",
+              "output": {"name": "displaced"},
+              "input": {"name": "physical"},
               "path": "displacementField",
               "interpolation": "linear",
               "name": "inverse-dfield"

--- a/2d/nonlinear/displacements.zarr/zarr.json
+++ b/2d/nonlinear/displacements.zarr/zarr.json
@@ -29,12 +29,12 @@
               "name": "displaced",
               "axes": [
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "y",
                   "discrete": false
                 },
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "x",
                   "discrete": false
                 }

--- a/2d/simple/affine.zarr/zarr.json
+++ b/2d/simple/affine.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -49,8 +49,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "array2physical",
                   "scale": [1, 1]
                 }
@@ -60,8 +60,8 @@
           "coordinateTransformations": [
             {
               "type": "affine",
-              "output": "sheared",
-              "input": "physical",
+              "output": {"name": "sheared"},
+              "input": {"name": "physical"},
               "name": "shear-transformation",
               "affine": [
                 [

--- a/2d/simple/affineParams.zarr/zarr.json
+++ b/2d/simple/affineParams.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -49,8 +49,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "array-to-physical",
                   "scale": [0.5, 0.5]
                 }
@@ -60,8 +60,8 @@
           "coordinateTransformations": [
             {
               "type": "affine",
-              "input": "physical",
-              "output": "sheared",
+              "input": {"name": "physical"},
+              "output": {"name": "sheared"},
               "path": "affineParams",
               "name": "shearing-transform"
             }

--- a/2d/simple/affine_multiscale.zarr/zarr.json
+++ b/2d/simple/affine_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -49,8 +49,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s0"},
                   "name": "scale0_to_physical",
                   "transformations": [
                     {
@@ -70,8 +70,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s1",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s1"},
                   "name": "scale1_to_physical",
                   "transformations": [
                     {
@@ -91,8 +91,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s2",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s2"},
                   "name": "scale2_to_physical",
                   "transformations": [
                     {
@@ -112,8 +112,8 @@
             {
               "type": "affine",
               "name": "physical-to-sheared",
-              "input": "physical",
-              "output": "sheared",
+              "input": {"name": "physical"},
+              "output": {"name": "sheared"},
               "affine": [
                 [
                   3,

--- a/2d/simple/multiscale.zarr/zarr.json
+++ b/2d/simple/multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s0"},
                   "name": "scale0_to_physical",
                   "transformations": [
                     {
@@ -53,8 +53,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s1",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s1"},
                   "name": "scale1_to_physical",
                   "transformations": [
                     {
@@ -74,8 +74,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s2",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s2"},
                   "name": "scale2_to_physical",
                   "transformations": [
                     {

--- a/2d/simple/rotation.zarr/zarr.json
+++ b/2d/simple/rotation.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -49,8 +49,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "scale": [1, 1],
                   "name": "array to physical"
                 }
@@ -60,8 +60,8 @@
           "coordinateTransformations":[
             {
               "name": "rotation",
-              "input": "physical",
-              "output": "rotated",
+              "input": {"name": "physical"},
+              "output": {"name": "rotated"},
               "type": "rotation",
               "rotation": [
                 [0, 1],

--- a/2d/simple/rotationParams.zarr/zarr.json
+++ b/2d/simple/rotationParams.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -49,8 +49,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "scale": [1.4, 1.4]
                 }
               ]
@@ -59,9 +59,9 @@
           "coordinateTransformations": [
             {
               "type": "rotation",
-              "output": "rotated",
+              "output": {"name": "rotated"},
               "path": "rotationParams",
-              "input": "physical",
+              "input": {"name": "physical"},
               "name": "image-rotation"
             }
           ]

--- a/3d/axis_dependent/byDimension.zarr/zarr.json
+++ b/3d/axis_dependent/byDimension.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -58,8 +58,8 @@
               "coordinateTransformations": [
                 {
                   "type": "identity",
-                  "input": "0",
-                  "output": "array"
+                  "input": {"path": "0"},
+                  "output": {"name": "array"}
                 }
               ]
 
@@ -68,8 +68,8 @@
           "coordinateTransformations": [
             {
               "type": "byDimension",
-              "output": "physical",
-              "input": "array",
+              "output": {"name": "physical"},
+              "input": {"name": "array"},
               "transformations": [
                 {
                   "type": "scale",

--- a/3d/axis_dependent/mapAxis.zarr/zarr.json
+++ b/3d/axis_dependent/mapAxis.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -58,8 +58,8 @@
               "coordinateTransformations": [
                 {
                   "type": "identity",
-                  "output": "array",
-                  "input": "0"
+                  "output": {"name": "array"},
+                  "input": {"path": "0"}
                 }
               ]
 
@@ -68,8 +68,8 @@
           "coordinateTransformations": [
             {
               "type": "mapAxis",
-              "output": "physical",
-              "input": "array",
+              "output": {"name": "physical"},
+              "input": {"name": "array"},
               "name": "transform-name",
               "mapAxis": [2, 1, 0]
             }

--- a/3d/basic/identity.zarr/zarr.json
+++ b/3d/basic/identity.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "identity",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "transform-name"
                 }
               ]

--- a/3d/basic/scale.zarr/zarr.json
+++ b/3d/basic/scale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -35,8 +35,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "transform-name",
                   "scale": [
                     4,

--- a/3d/basic/scale_multiscale.zarr/zarr.json
+++ b/3d/basic/scale_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "s0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s0"},
                   "name": "transform-name",
                   "scale": [
                     4,
@@ -54,8 +54,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "s1",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s1"},
                   "name": "transform-name",
                   "scale": [
                     8,
@@ -70,8 +70,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "s2",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s2"},
                   "name": "transform-name",
                   "scale": [
                     16,

--- a/3d/basic/sequenceScaleTranslation.zarr/zarr.json
+++ b/3d/basic/sequenceScaleTranslation.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/3d/basic/sequenceScaleTranslation_multiscale.zarr/zarr.json
+++ b/3d/basic/sequenceScaleTranslation_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s0"},
                   "transformations": [
                     {
                       "type": "scale",
@@ -68,8 +68,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s1",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s1"},
                   "transformations": [
                     {
                       "type": "scale",
@@ -98,8 +98,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s2",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s2"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/3d/nonlinear/coordinates.zarr/coordinatesField/zarr.json
+++ b/3d/nonlinear/coordinates.zarr/coordinatesField/zarr.json
@@ -72,8 +72,8 @@
       "coordinateTransformations": [
         {
           "type": "scale",
-          "output": "0",
-          "input": "0",
+          "output": {"name": "0"},
+          "input": {"name": "0"},
           "scale": [
             1,
             1,

--- a/3d/nonlinear/coordinates.zarr/coordinatesField/zarr.json
+++ b/3d/nonlinear/coordinates.zarr/coordinatesField/zarr.json
@@ -73,7 +73,6 @@
         {
           "type": "scale",
           "output": {"name": "0"},
-          "input": {"name": "0"},
           "scale": [
             1,
             1,

--- a/3d/nonlinear/coordinates.zarr/zarr.json
+++ b/3d/nonlinear/coordinates.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -58,8 +58,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "scale": [0.5, 0.5, 0.5],
                   "name": "array-to-physical"
                 }
@@ -69,8 +69,8 @@
           "coordinateTransformations": [
             {
               "type": "coordinates",
-              "output": "displaced",
-              "input": "physical",
+              "output": {"name": "displaced"},
+              "input": {"name": "physical"},
               "path": "coordinatesField",
               "interpolation": "linear",
               "name": "inverse-cfield"

--- a/3d/nonlinear/coordinates.zarr/zarr.json
+++ b/3d/nonlinear/coordinates.zarr/zarr.json
@@ -35,17 +35,17 @@
               "name": "physical",
               "axes": [
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "z",
                   "discrete": false
                 },
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "y",
                   "discrete": false
                 },
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "x",
                   "discrete": false
                 }

--- a/3d/nonlinear/invDisplacements.zarr/displacementField/zarr.json
+++ b/3d/nonlinear/invDisplacements.zarr/displacementField/zarr.json
@@ -79,7 +79,6 @@
         {
           "type": "scale",
           "output": {"name": "0"},
-          "input": {"name": "0"},
           "scale": [
             1,
             1,

--- a/3d/nonlinear/invDisplacements.zarr/displacementField/zarr.json
+++ b/3d/nonlinear/invDisplacements.zarr/displacementField/zarr.json
@@ -78,8 +78,8 @@
       "coordinateTransformations": [
         {
           "type": "scale",
-          "output": "0",
-          "input": "0",
+          "output": {"name": "0"},
+          "input": {"name": "0"},
           "scale": [
             1,
             1,

--- a/3d/nonlinear/invDisplacements.zarr/zarr.json
+++ b/3d/nonlinear/invDisplacements.zarr/zarr.json
@@ -35,17 +35,17 @@
               "name": "physical",
               "axes": [
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "z",
                   "discrete": false
                 },
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "y",
                   "discrete": false
                 },
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "x",
                   "discrete": false
                 }

--- a/3d/nonlinear/invDisplacements.zarr/zarr.json
+++ b/3d/nonlinear/invDisplacements.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -58,8 +58,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "scale": [0.5, 0.5, 0.5],
                   "name": "scale-transform"
                 }
@@ -70,8 +70,8 @@
           "coordinateTransformations": [
             {
               "type": "displacements",
-              "output": "physical",
-              "input": "displaced",
+              "output": {"name": "physical"},
+              "input": {"name": "displaced"},
               "path": "displacementField",
               "interpolation": "linear",
               "name": "inverse-dfield"

--- a/3d/simple/affine.zarr/zarr.json
+++ b/3d/simple/affine.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -61,8 +61,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "array-to-physical",
                   "scale": [
                     1,
@@ -76,8 +76,8 @@
           "coordinateTransformations": [
             {
               "type": "affine",
-              "output": "sheared",
-              "input": "physical",
+              "output": {"name": "sheared"},
+              "input": {"name": "physical"},
               "name": "physical-to-sheared",
               "affine": [
                 [

--- a/3d/simple/affineParams.zarr/zarr.json
+++ b/3d/simple/affineParams.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -62,8 +62,8 @@
                 {
                   "type": "scale",
                   "scale": [1.0, 0.5, 0.5],
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "image-to-physical"
                 }
               ]
@@ -72,8 +72,8 @@
           "coordinateTransformations": [
             {
               "type": "affine",
-              "input": "physical",
-              "output": "sheared",
+              "input": {"name": "physical"},
+              "output": {"name": "sheared"},
               "path": "affineParams",
               "name": "physical-to-sheared"
             }

--- a/3d/simple/affine_multiscale.zarr/zarr.json
+++ b/3d/simple/affine_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -61,8 +61,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s0"},
                   "name": "s0 to physical",
                   "transformations": [
                     {
@@ -90,8 +90,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s1",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s1"},
                   "name": "s1 to physical",
                   "transformations": [
                     {
@@ -119,8 +119,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s2",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s2"},
                   "name": "s2 to physical",
                   "transformations": [
                     {
@@ -147,8 +147,8 @@
           "coordinateTransformations": [
             {
               "type": "affine",
-              "output": "sheared",
-              "input": "physical",
+              "output": {"name": "sheared"},
+              "input": {"name": "physical"},
               "name": "physical-to-sheared",
               "affine": [
                 [

--- a/3d/simple/rotation.zarr/zarr.json
+++ b/3d/simple/rotation.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -61,8 +61,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "scale": [1, 1, 1],
                   "name": "array-to-physical"
                 }
@@ -72,8 +72,8 @@
           "coordinateTransformations": [
             {
               "type": "rotation",
-              "output": "rotated",
-              "input": "physical",
+              "output": {"name": "rotated"},
+              "input": {"name": "physical"},
               "rotation": [
                 [
                   0,

--- a/3d/simple/rotationParams.zarr/zarr.json
+++ b/3d/simple/rotationParams.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -62,8 +62,8 @@
                 {
                   "type": "scale",
                   "scale": [1, 1, 1],
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "array-to-physical"
                 }
               ]
@@ -72,9 +72,9 @@
           "coordinateTransformations": [
             {
               "type": "rotation",
-              "output": "rotated",
+              "output": {"name": "rotated"},
               "path": "rotationParams",
-              "input": "physical",
+              "input": {"name": "physical"},
               "name": "physical-to-rotated"
             }
           ]

--- a/user_stories/SCAPE.zarr/stack/zarr.json
+++ b/user_stories/SCAPE.zarr/stack/zarr.json
@@ -1,7 +1,7 @@
 {
 	"attributes": {
 		"ome": {
-			"version": "0.6.dev3",
+			"version": "0.6.dev4",
 			"multiscales": [
 				{
 					"coordinateSystems": [
@@ -56,8 +56,8 @@
 								{
                                     "name": "scale0 to physical",
                                     "type": "sequence",
-                                    "input": "scale0",
-                                    "output": "physical",
+                                    "input": {"path": "scale0"},
+                                    "output": {"name": "physical"},
                                     "transformations": [
                                         {
                                             "type": "scale",
@@ -85,8 +85,8 @@
 								{
 									"type": "sequence",
 									"name": "scale1 to physical",
-									"input": "scale1",
-									"output": "physical",
+									"input": {"path": "scale1"},
+									"output": {"name": "physical"},
 									"transformations": [
 										{
 											"scale": [
@@ -112,8 +112,8 @@
 					"coordinateTransformations":[
 						{
 							"name": "deskewing",
-							"input": "physical",
-							"output": "unskewed",
+							"input": {"name": "physical"},
+							"output": {"name": "unskewed"},
 							"type": "affine",
 							"affine": [
 								[1.0, 0.0, 0.0, 0.0],

--- a/user_stories/SCAPE.zarr/zarr.json
+++ b/user_stories/SCAPE.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "scene": {
         "coordinateTransformations": [
           {

--- a/user_stories/human_organ_atlas.zarr/VOI-01.ome.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/VOI-01.ome.zarr/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "0",
-                  "output": "physical",
+                  "input": {"path": "0"},
+                  "output": {"name": "physical"},
                   "transformations": [
                     {
                       "type": "scale",
@@ -58,8 +58,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "1",
-                  "output": "physical",
+                  "input": {"path": "1"},
+                  "output": {"name": "physical"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/user_stories/human_organ_atlas.zarr/VOI-02.ome.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/VOI-02.ome.zarr/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "0",
-                  "output": "physical",
+                  "input": {"path": "0"},
+                  "output": {"name": "physical"},
                   "transformations": [
                     {
                       "type": "scale",
@@ -58,8 +58,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "1",
-                  "output": "physical",
+                  "input": {"path": "1"},
+                  "output": {"name": "physical"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/user_stories/human_organ_atlas.zarr/VOI-03.ome.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/VOI-03.ome.zarr/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "0",
-                  "output": "physical",
+                  "input": {"path": "0"},
+                  "output": {"name": "physical"},
                   "transformations": [
                     {
                       "type": "scale",
@@ -58,8 +58,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "1",
-                  "output": "physical",
+                  "input": {"path": "1"},
+                  "output": {"name": "physical"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/user_stories/human_organ_atlas.zarr/overview.ome.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/overview.ome.zarr/zarr.json
@@ -58,8 +58,8 @@
           "coordinateTransformations": [
             {
               "type": "sequence",
-              "input": "physical",
-              "output": "anatomical",
+              "input": {"name": "physical"},
+              "output": {"name": "anatomical"},
               "transformations": [
                 {
                   "type": "rotation",
@@ -79,8 +79,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "0",
-                  "output": "physical",
+                  "input": {"path": "0"},
+                  "output": {"name": "physical"},
                   "transformations": [
                     {
                       "type": "scale",
@@ -99,8 +99,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "1",
-                  "output": "physical",
+                  "input": {"path": "1"},
+                  "output": {"name": "physical"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/user_stories/human_organ_atlas.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "scene":{
         "coordinateTransformations": [
           {

--- a/user_stories/image_registration_3d.zarr/FCWB/zarr.json
+++ b/user_stories/image_registration_3d.zarr/FCWB/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "FCWB",
-                  "input": "s0",
+                  "output": {"name": "FCWB"},
+                  "input": {"path": "s0"},
                   "scale": [
                     1.2,
                     1.2,
@@ -53,8 +53,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "FCWB",
-                  "input": "s1",
+                  "output": {"name": "FCWB"},
+                  "input": {"path": "s1"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/user_stories/image_registration_3d.zarr/JRC2018F/zarr.json
+++ b/user_stories/image_registration_3d.zarr/JRC2018F/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "JRC2018F",
-                  "input": "s0",
+                  "output": {"name": "JRC2018F"},
+                  "input": {"path": "s0"},
                   "scale": [
                     1.24296,
                     1.24296,
@@ -53,8 +53,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "s1",
-                  "output": "JRC2018F",
+                  "input": {"path": "s1"},
+                  "output": {"name": "JRC2018F"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/user_stories/image_registration_3d.zarr/coordinateTransformations/dfield/zarr.json
+++ b/user_stories/image_registration_3d.zarr/coordinateTransformations/dfield/zarr.json
@@ -81,8 +81,7 @@
       "coordinateTransformations": [
         {
           "type": "scale",
-          "output": "JRC2018F",
-          "input": "dfield",
+          "output": {"name": "JRC2018F"},
           "name": "",
           "scale": [
             1.76,

--- a/user_stories/image_registration_3d.zarr/coordinateTransformations/invdfield/zarr.json
+++ b/user_stories/image_registration_3d.zarr/coordinateTransformations/invdfield/zarr.json
@@ -75,8 +75,7 @@
       "coordinateTransformations": [
         {
           "type": "scale",
-          "output": "FCWB",
-          "input": "invdfield",
+          "output": {"name": "FCWB"},
           "name": "",
           "scale": [
             1.76,

--- a/user_stories/image_registration_3d.zarr/zarr.json
+++ b/user_stories/image_registration_3d.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "scene": {
         "coordinateTransformations": [
           {

--- a/user_stories/lens_correction.zarr/coordinateTransformations/lensCorrection/zarr.json
+++ b/user_stories/lens_correction.zarr/coordinateTransformations/lensCorrection/zarr.json
@@ -68,7 +68,6 @@
         {
           "type": "scale",
           "output": {"name": "raw2d"},
-          "input": {"path": "."},
           "name": "displacement field sample spacing",
           "scale": [
             5,

--- a/user_stories/lens_correction.zarr/coordinateTransformations/lensCorrection/zarr.json
+++ b/user_stories/lens_correction.zarr/coordinateTransformations/lensCorrection/zarr.json
@@ -67,8 +67,8 @@
       "coordinateTransformations": [
         {
           "type": "scale",
-          "output": "raw2d",
-          "input": ".",
+          "output": {"name": "raw2d"},
+          "input": {"path": "."},
           "name": "displacement field sample spacing",
           "scale": [
             5,

--- a/user_stories/lens_correction.zarr/image/zarr.json
+++ b/user_stories/lens_correction.zarr/image/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "raw",
-                  "input": "0",
+                  "output": {"name": "raw"},
+                  "input": {"path": "0"},
                   "scale": [
                     1,
                     1,

--- a/user_stories/lens_correction.zarr/zarr.json
+++ b/user_stories/lens_correction.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "scene": {
         "coordinateTransformations": [
           {

--- a/user_stories/stitched_tiles_2d.zarr/tile_0/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/tile_0/zarr.json
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_0 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_2d.zarr/tile_1/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/tile_1/zarr.json
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_1 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_2d.zarr/tile_2/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/tile_2/zarr.json
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_2 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_2d.zarr/tile_3/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/tile_3/zarr.json
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_3 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_2d.zarr/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "scene": {
         "coordinateTransformations": [
           {

--- a/user_stories/stitched_tiles_3d.zarr/tile_0/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_0/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_0 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_3d.zarr/tile_1/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_1/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_1 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_3d.zarr/tile_2/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_2/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_2 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_3d.zarr/tile_3/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_3/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_3 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_3d.zarr/tile_4/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_4/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_4 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_3d.zarr/tile_5/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_5/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_5 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_3d.zarr/tile_6/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_6/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_6 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_3d.zarr/tile_7/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_7/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_7 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_3d.zarr/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "scene": {
         "coordinateTransformations": [
           {


### PR DESCRIPTION
In the metadata of coordinates or displacement fields, the transform is stored in the metadata of the array itself. Thus, the input field can be omitted in this circumstance.